### PR TITLE
Fix/workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
               echo "WIRESHARK_LIB_DIR=${{ github.workspace }}" >> $GITHUB_OUTPUT
               ;;
             *windows*)
-              echo "WIRESHARK_LIB_DIR=C:\\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3" >> $GITHUB_OUTPUT
+              echo "WIRESHARK_LIB_DIR=C:\Development\wireshark-4.2.3" >> $GITHUB_OUTPUT
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
               ln -snf $(find /Applications/Wireshark.app/Contents/Frameworks -name "libwireshark.*.dylib" | tail -n 1) libwireshark.dylib
               echo "WIRESHARK_LIB_DIR=${{ github.workspace }}" >> $GITHUB_OUTPUT
               ;;
+            *windows*)
+              echo "WIRESHARK_LIB_DIR=C:\\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3" >> $GITHUB_OUTPUT
+              ;;
           esac
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,6 @@ jobs:
               ln -snf $(find /Applications/Wireshark.app/Contents/Frameworks -name "libwireshark.*.dylib" | tail -n 1) libwireshark.dylib
               echo "WIRESHARK_LIB_DIR=${{ github.workspace }}" >> $GITHUB_OUTPUT
               ;;
-            *windows*)
-              echo "WIRESHARK_LIB_DIR=" >> $GITHUB_OUTPUT
-              ;;
           esac
 
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   WIRESHARK_VERSION: 4.2
   # Use the pre-built wireshark library to speed up
-  WIRESHARK_LIB_DIR: C:\\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3
+  WIRESHARK_LIB_DIR: C:\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3
 
 jobs:
   check:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,8 @@ on:
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   WIRESHARK_VERSION: 4.2
+  # Use the pre-built wireshark library to speed up
+  WIRESHARK_LIB_DIR: C:\\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3
 
 jobs:
   check:
@@ -62,8 +64,6 @@ jobs:
         with:
           command: fmt
           args: -- --check
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   WIRESHARK_VERSION: 4.2
   # Use the pre-built wireshark library to speed up
-  WIRESHARK_LIB_DIR: C:\Users\zenoh\source\repos\zenoh-dissector\epan-sys\wireshark-4.2.3
+  WIRESHARK_LIB_DIR: C:\Development\wireshark-4.2.3
 
 jobs:
   check:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-10, windows-11]
+        os:
+          - windows-10
+
+          # Disable Win11 since
+          # 1. The user name issue zenog -> zenoh
+          # 2. Fail to build from source with Rust
+          # - windows-11
 
     steps:
       - uses: actions/checkout@v3

--- a/epan-sys/build.rs
+++ b/epan-sys/build.rs
@@ -40,24 +40,21 @@ fn link_wireshark() -> Result<()> {
     println!("cargo:rerun-if-env-changed=WIRESHARK_LIB_DIR");
     if let Ok(libws_dir) = env::var("WIRESHARK_LIB_DIR") {
         println!("cargo:rustc-link-search=native={}", libws_dir);
-    }
+    } else {
+        // warn: eventually we don't use this directly due to the privilege issue.
+        // instead, we will link the /applications/wireshark.app/contents/frameworks/libwireshark.*.dylib
+        // to libwireshark.dylib under the project folder and configure it via WIRESHARK_LIB_DIR
+        //
+        // // Default wireshark libraray installed on macos
+        // #[cfg(target_os = "macos")]
+        // {
+        //     let macos_wireshark_library = "/Applications/wireshark.app/contents/frameworks";
+        //     if !PathBuf::from(macos_wireshark_library).exists() {
+        //         panic!("wireshark library not found at {macos_wireshark_library}");
+        //     }
+        //     println!("cargo:rustc-link-search=native={macos_wireshark_library}");
+        // }
 
-    // WARN: Eventually we don't use this directly due to the privilege issue.
-    // Instead, we will link the /Applications/Wireshark.app/Contents/Frameworks/libwireshark.*.dylib
-    // to libwireshark.dylib under the project folder and configure it via WIRESHARK_LIB_DIR
-    //
-    // // Default wireshark libraray installed on macos
-    // #[cfg(target_os = "macos")]
-    // {
-    //     let macos_wireshark_library = "/Applications/wireshark.app/contents/frameworks";
-    //     if !PathBuf::from(macos_wireshark_library).exists() {
-    //         panic!("wireshark library not found at {macos_wireshark_library}");
-    //     }
-    //     println!("cargo:rustc-link-search=native={macos_wireshark_library}");
-    // }
-
-    #[cfg(target_os = "windows")]
-    {
         if !WIRESHARK_BUILD_DIR.exists() {
             download_wireshark(true)?;
             build_wireshark();

--- a/epan-sys/build.rs
+++ b/epan-sys/build.rs
@@ -41,7 +41,10 @@ fn link_wireshark() -> Result<()> {
     if let Ok(libws_dir) = env::var("WIRESHARK_LIB_DIR") {
         println!("cargo:rustc-link-search=native={}", libws_dir);
     } else {
-        // warn: eventually we don't use this directly due to the privilege issue.
+        // WARN: We can't build from source with cmake if WIRESHARK_LIB_DIR is set. That's why we
+        // need to separate these two branches.
+
+        // WARN: eventually we don't use this directly due to the privilege issue.
         // instead, we will link the /applications/wireshark.app/contents/frameworks/libwireshark.*.dylib
         // to libwireshark.dylib under the project folder and configure it via WIRESHARK_LIB_DIR
         //
@@ -122,7 +125,6 @@ fn generate_bindings() -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "windows", feature = "bindgen"))]
 fn download_wireshark(skip_existing: bool) -> Result<()> {
     if skip_existing && WIRESHARK_SOURCE_DIR.exists() {
         return Ok(());
@@ -155,7 +157,6 @@ fn download_wireshark(skip_existing: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "windows", feature = "bindgen"))]
 fn build_wireshark() {
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
* Failed to build from source with Rust on our win11 machine. Several issues are identified but will take some time to resolve so disable it for the time being.
* Fix the conflict with building from source on Windows.
* Use the pre-built wireshark library to skip the duplicated compiling process. Shrink from 10 minutes to 3 minutes.