### PR TITLE
Fix aarch64 c char

### DIFF
--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -19,7 +19,6 @@ use zenoh_impl::ZenohProtocol;
 
 use zenoh_protocol::transport::{BatchSize, TransportMessage};
 
-
 #[no_mangle]
 #[used]
 static plugin_version: [std::ffi::c_char; 6usize] = [48, 46, 50, 46, 48, 0]; // "0.2.0\0"

--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -19,9 +19,10 @@ use zenoh_impl::ZenohProtocol;
 
 use zenoh_protocol::transport::{BatchSize, TransportMessage};
 
+
 #[no_mangle]
 #[used]
-static plugin_version: [std::ffi::c_char; 6usize] = [48i8, 46i8, 48i8, 46i8, 49i8, 0i8];
+static plugin_version: [std::ffi::c_char; 6usize] = [48, 46, 50, 46, 48, 0]; // "0.2.0\0"
 #[no_mangle]
 #[used]
 static plugin_want_major: std::ffi::c_int = 4;


### PR DESCRIPTION
To address the failure while mistakenly conversion between `std::ffi::c_char` and `i8`  on aarch64. See [this CI check](https://github.com/ZettaScaleLabs/zenoh-dissector/actions/runs/8715628099/job/23907995450#step:6:150) for details.